### PR TITLE
booksページをスクロールで表示に変更・デザイン変更

### DIFF
--- a/src/auth/LoginModal.jsx
+++ b/src/auth/LoginModal.jsx
@@ -4,11 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { login, logout } from "../store/slice/userSlice";
 import { FormProvider, useForm } from "react-hook-form";
 import { css } from "@emotion/react";
-import {
-  buttonContainerStyle,
-  formStyle,
-  errorMessageStyle,
-} from "../styles/styles";
+import { buttonContainerStyle, formStyle } from "../styles/styles";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { formSchema } from "../lib/schema";
 import useToast from "../hooks/useToast";
@@ -59,6 +55,12 @@ const menuTextStyle = css`
   }
 `;
 
+const loginButtonContainerStyle = css`
+  margin-top: 20px;
+  margin-bottom: 10px;
+  margin-right: auto;
+  margin-left: auto;
+`;
 const LoginModal = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -135,22 +137,19 @@ const LoginModal = () => {
                 <span css={formTextStyle}>ログイン</span>
                 <TextInput
                   type="email"
-                  label="メールアドレス"
+                  label="ログイン用メールアドレス"
                   placeholder="メールアドレスを入力してください"
                   name="email"
                 />
                 <TextInput
                   type="password"
-                  label="パスワード"
+                  label="登録済みパスワード"
                   placeholder="8～12文字で入力してください"
                   name="password"
                 />
-                <div css={buttonContainerStyle}>
+                <div css={loginButtonContainerStyle}>
                   <Button type="submit" color="blue">
                     ログイン
-                  </Button>
-                  <Button type="submit" color="gray">
-                    googleでログイン
                   </Button>
                 </div>
               </form>

--- a/src/pages/Books.jsx
+++ b/src/pages/Books.jsx
@@ -9,12 +9,11 @@ import AddBookModal from "../components/book/AddBookModal";
 import EditBookModal from "../components/book/EditBookModal";
 
 const bookContainerStyle = css`
-  padding: 0 1.8rem;
+  padding: 0 1.6rem;
 `;
 
 const addBookContainerStyle = css`
-  background-color: white;
-  padding-bottom: 52px;
+  padding-top: 25px;
   padding-left: 25px;
   padding-right: 25px;
   border-radius: 4px;
@@ -26,8 +25,9 @@ const bookTitleStyle = css`
 `;
 
 const BooksAreaStyle = css`
+  width: 100%;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
   margin: 0 auto;
@@ -89,6 +89,40 @@ const h2Style = css`
   font-size: 1.2rem;
 `;
 
+const scrollStyle = css`
+  position: relative;
+  display: flex;
+  overflow-x: auto;
+  gap: 1.5rem;
+  margin: 20px 0;
+  padding: 2rem 1rem;
+  background-color: #fff;
+  border-radius: 12px;
+  box-shadow: 0 -5px 10px rgba(0, 0, 0, 0.15);
+  border: 2px solid #c9b79c;
+
+  &::-webkit-scrollbar {
+    height: 12px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #e0d8c9;
+    border-radius: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #b59d7c;
+    border-radius: 10px;
+    border: 2px solid #e0d8c9;
+  }
+
+  @media (max-width: 960px) {
+    margin: 20px 0;
+    border: 2px solid #ccc;
+    border-radius: 8px;
+  }
+`;
+
 const Books = () => {
   const dispatch = useDispatch();
   const books = useSelector((state) => state.books.books);
@@ -111,6 +145,20 @@ const Books = () => {
     return <p css={loadingStyle}>Loading ...</p>;
   }
 
+  // AddBookModal を最後の1つとして追加
+  const booksWithAdd = [...books, { _id: "add", isAdd: true }];
+
+  // 4つずつ分割
+  const chunkArray = (array, chunkSize) => {
+    const result = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+      result.push(array.slice(i, i + chunkSize));
+    }
+    return result;
+  };
+
+  const chunkedBooks = chunkArray(booksWithAdd, 4);
+
   return (
     <>
       <Helmet>
@@ -124,29 +172,36 @@ const Books = () => {
       <div css={main1ColumnStyle}>
         <h1>メモブックの一覧</h1>
         <div css={BooksAreaStyle}>
-          {books.map((book) => (
-            <div css={bookContainerStyle} key={book._id}>
-              <Link
-                to={
-                  book.firstChapterId
-                    ? `/${book._id}/${book.firstChapterId}`
-                    : `/${book._id}`
-                }
-              >
-                <div css={bookStyle}>
-                  <div css={bookTitleStyle}>
-                    <h2 css={h2Style}>{book.title}</h2>
+          {chunkedBooks.map((row, index) => (
+            <div css={scrollStyle} key={index}>
+              {row.map((book) =>
+                book.isAdd ? (
+                  <div css={addBookContainerStyle} key="add">
+                    <AddBookModal />
                   </div>
-                </div>
-              </Link>
-              <div css={editButtonContainerStyle}>
-                <EditBookModal bookTitle={book.title} bookId={book._id} />
-              </div>
+                ) : (
+                  <div css={bookContainerStyle} key={book._id}>
+                    <Link
+                      to={
+                        book.firstChapterId
+                          ? `/${book._id}/${book.firstChapterId}`
+                          : `/${book._id}`
+                      }
+                    >
+                      <div css={bookStyle}>
+                        <div css={bookTitleStyle}>
+                          <h2 css={h2Style}>{book.title}</h2>
+                        </div>
+                      </div>
+                    </Link>
+                    <div css={editButtonContainerStyle}>
+                      <EditBookModal bookTitle={book.title} bookId={book._id} />
+                    </div>
+                  </div>
+                )
+              )}
             </div>
           ))}
-          <div css={addBookContainerStyle}>
-            <AddBookModal />
-          </div>
         </div>
       </div>
     </>

--- a/src/pages/Books.jsx
+++ b/src/pages/Books.jsx
@@ -4,7 +4,7 @@ import { Helmet } from "react-helmet-async";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchBooks } from "../store/slice/booksSlice";
 import { css } from "@emotion/react";
-import { main1ColumnStyle, oneColumnContainerStyle } from "../styles/styles";
+import { main1ColumnStyle } from "../styles/styles";
 import AddBookModal from "../components/book/AddBookModal";
 import EditBookModal from "../components/book/EditBookModal";
 
@@ -122,32 +122,30 @@ const Books = () => {
         <meta name="robots" content="noindex" />
       </Helmet>
       <div css={main1ColumnStyle}>
-        <div css={oneColumnContainerStyle}>
-          <h1>メモブックの一覧</h1>
-          <div css={BooksAreaStyle}>
-            {books.map((book) => (
-              <div css={bookContainerStyle} key={book._id}>
-                <Link
-                  to={
-                    book.firstChapterId
-                      ? `/${book._id}/${book.firstChapterId}`
-                      : `/${book._id}`
-                  }
-                >
-                  <div css={bookStyle}>
-                    <div css={bookTitleStyle}>
-                      <h2 css={h2Style}>{book.title}</h2>
-                    </div>
+        <h1>メモブックの一覧</h1>
+        <div css={BooksAreaStyle}>
+          {books.map((book) => (
+            <div css={bookContainerStyle} key={book._id}>
+              <Link
+                to={
+                  book.firstChapterId
+                    ? `/${book._id}/${book.firstChapterId}`
+                    : `/${book._id}`
+                }
+              >
+                <div css={bookStyle}>
+                  <div css={bookTitleStyle}>
+                    <h2 css={h2Style}>{book.title}</h2>
                   </div>
-                </Link>
-                <div css={editButtonContainerStyle}>
-                  <EditBookModal bookTitle={book.title} bookId={book._id} />
                 </div>
+              </Link>
+              <div css={editButtonContainerStyle}>
+                <EditBookModal bookTitle={book.title} bookId={book._id} />
               </div>
-            ))}
-            <div css={addBookContainerStyle}>
-              <AddBookModal />
             </div>
+          ))}
+          <div css={addBookContainerStyle}>
+            <AddBookModal />
           </div>
         </div>
       </div>

--- a/src/styles/styles.mjs
+++ b/src/styles/styles.mjs
@@ -35,8 +35,8 @@ export const RightContent = css`
   max-width: 1060px;
   width: 100%;
   min-height: 100vh;
-  margin-left: 220px;
-  padding-left: 60px;
+  margin-left: 200px;
+  padding-left: 100px;
   padding-right: 20px;
   background-color: #ffffff;
 

--- a/src/styles/styles.mjs
+++ b/src/styles/styles.mjs
@@ -11,7 +11,7 @@ export const main1ColumnStyle = css`
   h1 {
     font-size: 30px;
     text-align: center;
-    margin-bottom: 80px;
+    margin-bottom: 40px;
     margin-top: 0;
   }
 `;

--- a/src/styles/styles.mjs
+++ b/src/styles/styles.mjs
@@ -6,6 +6,7 @@ export const main1ColumnStyle = css`
   max-width: 1140px;
   min-height: calc(100vh - 229px);
   margin: 0px auto;
+  padding: 60px 20px;
 
   h1 {
     font-size: 30px;
@@ -18,7 +19,6 @@ export const main1ColumnStyle = css`
 // 1カラム時のコンテナ
 export const oneColumnContainerStyle = css`
   background-color: white;
-  margin: 60px 16px;
   padding: 60px 20px;
   border: 1px solid #d7d7d7;
   border-radius: 4px;
@@ -65,7 +65,6 @@ export const modalBackStyle = css`
   height: 100%;
   background-color: rgb(156 163 175 / 65%);
   z-index: 1000;
-  padding: 0 10px;
 `;
 
 export const modalContainerStyle = css`


### PR DESCRIPTION
## booksページをスクロールで表示に変更

- booksページのデザインを変更
- PC以下のサイズでは本棚をスクロールで表示に変更

booksページがスマホの表示などの際に、縦一列で表示になっており、数が多いと味気ない感じがあった。
そのため、横にスクロールができるようにスタイルを変更を行う。
横に最大で4個まで表示をして、5個目以降は2列目に表示がされ、左右へのスクロールが可能に。
以降、4個ずつで列ができるようにしている。
